### PR TITLE
Upgrade dependancies and runtime.

### DIFF
--- a/src/Marten.AspNetIdentity.Example/Marten.AspNetIdentity.Example.csproj
+++ b/src/Marten.AspNetIdentity.Example/Marten.AspNetIdentity.Example.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 		<UserSecretsId>aspnet-Examples.MvcSecurity-ADC7C261-1B6F-4EAB-8654-2C14BC7254E6</UserSecretsId>
 		<RootNamespace>Marten.AspNetIdentity.Example</RootNamespace>
 	</PropertyGroup>

--- a/src/Marten.AspNetIdentity.Example/Startup.cs
+++ b/src/Marten.AspNetIdentity.Example/Startup.cs
@@ -23,7 +23,7 @@ namespace Marten.AspNetIdentity.Example
 		{
 			services.AddLogging();
 
-			string connectionString = "server=localhost;database=aspnetidentity;uid=aspnetidentity;pwd=aspnetidentity;";
+			string connectionString = "Host=localhost;Port=5432;Database=aspnetidentity;Username=aspnetidentity;Password=aspnetidentity;";
 
 			services.AddIdentity<ApplicationUser, IdentityRole>()
 				.AddMartenStores<ApplicationUser, IdentityRole>(connectionString)

--- a/src/Marten.AspNetIdentity.Tests/Marten.AspNetIdentity.Tests.csproj
+++ b/src/Marten.AspNetIdentity.Tests/Marten.AspNetIdentity.Tests.csproj
@@ -1,17 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
-    <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="Testcontainers" Version="3.8.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.8.0" />
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Marten.AspNetIdentity.Tests/PostgresSqlFixture.cs
+++ b/src/Marten.AspNetIdentity.Tests/PostgresSqlFixture.cs
@@ -1,31 +1,28 @@
 using System.Threading.Tasks;
-using DotNet.Testcontainers.Containers.Builders;
-using DotNet.Testcontainers.Containers.Configurations.Databases;
-using DotNet.Testcontainers.Containers.Modules.Databases;
+using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace Marten.AspNetIdentity.Tests
 {
     public class PostgresSqlFixture : IAsyncLifetime
     {
-        private readonly PostgreSqlTestcontainer _testContainer;
+        private readonly PostgreSqlContainer _testContainer;
         
         public PostgresSqlFixture()
         {
-            var testContainerBuilder = new TestcontainersBuilder<PostgreSqlTestcontainer>()
+            var testContainerBuilder = new PostgreSqlBuilder()
                 .WithCleanUp(true)
-                .WithDatabase(new PostgreSqlTestcontainerConfiguration
-                {
-                    Database = "aspnetidentity",
-                    Username = "aspnetidentity",
-                    Password = "aspnetidentity"
-                })
+                .WithPortBinding(5432, true)
+                .WithDatabase("aspnetidentity")
+                .WithPassword("aspnetidentity")
+                .WithUsername("aspnetidentity")
+                .WithExposedPort(5432)
                 .WithImage("clkao/postgres-plv8");
 
             _testContainer = testContainerBuilder.Build();
         }
 
-        public string ConnectionString => _testContainer.ConnectionString;
+        public string ConnectionString => _testContainer.GetConnectionString();
         
         public async Task InitializeAsync()
         {
@@ -36,6 +33,7 @@ namespace Marten.AspNetIdentity.Tests
                 "/bin/sh", "-c",
                 "psql -U aspnetidentity -c \"CREATE EXTENSION plv8; SELECT extversion FROM pg_extensions WHERE extname = 'plv8';\""
             });
+            var thing = string.Empty;
         }
 
         public async Task DisposeAsync()

--- a/src/Marten.AspNetIdentity/Marten.AspNetIdentity.csproj
+++ b/src/Marten.AspNetIdentity/Marten.AspNetIdentity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 		<Description>A Marten implementation of the ASP.NET Core Identity stores.</Description>
 		<PackageProjectUrl>https://github.com/roadkillwiki/Marten.AspNetIdentity</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/yetanotherchris/MartenAspNetIdentity</RepositoryUrl>
@@ -12,11 +12,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Marten" Version="3.10.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="3.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
+		<PackageReference Include="Marten" Version="7.9.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.4" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.4" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
 	</ItemGroup>
 </Project>

--- a/src/Marten.AspNetIdentity/MartenRoleStore.cs
+++ b/src/Marten.AspNetIdentity/MartenRoleStore.cs
@@ -36,7 +36,7 @@ namespace Marten.AspNetIdentity
 		{
 			try
 			{
-				using (IDocumentSession session = _documentStore.OpenSession())
+				using (IDocumentSession session = _documentStore.LightweightSession())
 				{
 					session.Store(role);
 					await session.SaveChangesAsync(cancellationToken);
@@ -55,7 +55,7 @@ namespace Marten.AspNetIdentity
 		{
 			try
 			{
-				using (IDocumentSession session = _documentStore.OpenSession())
+				using (IDocumentSession session = _documentStore.LightweightSession())
 				{
 					session.Update(role);
 					await session.SaveChangesAsync(cancellationToken);
@@ -74,7 +74,7 @@ namespace Marten.AspNetIdentity
 		{
 			try
 			{
-				using (IDocumentSession session = _documentStore.OpenSession())
+				using (IDocumentSession session = _documentStore.LightweightSession())
 				{
 					session.Delete(role);
 					await session.SaveChangesAsync(cancellationToken);

--- a/src/Marten.AspNetIdentity/MartenUserStore.cs
+++ b/src/Marten.AspNetIdentity/MartenUserStore.cs
@@ -36,7 +36,7 @@ namespace Marten.AspNetIdentity
 
 		public void Wipe()
 		{
-			using (IDocumentSession session = _documentStore.OpenSession())
+			using (IDocumentSession session = _documentStore.LightweightSession())
 			{
 				session.DeleteWhere<TUser>(x => true);
 				session.SaveChanges();
@@ -82,7 +82,7 @@ namespace Marten.AspNetIdentity
 
 			try
 			{
-				using (IDocumentSession session = _documentStore.OpenSession())
+				using (IDocumentSession session = _documentStore.LightweightSession())
 				{
 					session.Store(user);
 					await session.SaveChangesAsync(cancellationToken);
@@ -100,7 +100,7 @@ namespace Marten.AspNetIdentity
 		{
 			try
 			{
-				using (IDocumentSession session = _documentStore.OpenSession())
+				using (IDocumentSession session = _documentStore.LightweightSession())
 				{
 					session.Update(user);
 					await session.SaveChangesAsync(cancellationToken);
@@ -118,7 +118,7 @@ namespace Marten.AspNetIdentity
 		{
 			try
 			{
-				using (IDocumentSession session = _documentStore.OpenSession())
+				using (IDocumentSession session = _documentStore.LightweightSession())
 				{
 					session.Delete(user);
 					await session.SaveChangesAsync(cancellationToken);
@@ -316,7 +316,7 @@ namespace Marten.AspNetIdentity
 
 				user.RoleClaims = userRoleClaims;
 
-				using (IDocumentSession session = _documentStore.OpenSession())
+				using (IDocumentSession session = _documentStore.LightweightSession())
 				{
 					session.Store(user);
 					await session.SaveChangesAsync(cancellationToken);


### PR DESCRIPTION
This change upgrades the target framework to .net 8 and upgrades all dependencies to latest.
Includes a small fix for the Sample app connection string for connection to the Docker postgresql instance.
NOTE: The Testcontainer usage in PostgreSqlFixture is currently timing out while waiting for the container to start.  This is an outstanding issue to resolve.